### PR TITLE
Add support for roll-over when files are bigger than 65536 * blksize

### DIFF
--- a/TFTP.pm
+++ b/TFTP.pm
@@ -691,7 +691,7 @@ sub _write {
     my $retry   = 0;
 
     return _send_data($self)
-	if $self->{'ack'} == $self->{'blk'};
+	if $self->{'ack'} == $self->{'blk'} % 65536;
 
     while(1) {
 	if($select->can_read($timeout)) {
@@ -707,11 +707,11 @@ sub _write {
 	    }
 
 	    if($code == Net::TFTP::ACK) {
-		if ($self->{'blk'} == $blk) {
+		if ($self->{'blk'} % 65536 == $blk) {
 		    $self->{'ack'} = $blk;
 		    return _send_data($self);
 		}
-		elsif ($self->{'blk'} > $blk) {
+		elsif ($self->{'blk'} % 65536 > $blk) {
 		    redo; # duplicate ACK
 		}
 	    }


### PR DESCRIPTION
According to Wikipedia: "Today most servers and clients support block number roll-over (block counter going back to 0 after 65535) then the transfer file size is essentially unlimited."

This patch series enables this behaviour.
